### PR TITLE
Fix broken link for Material commit message guidelines

### DIFF
--- a/CONTRIBUTING-template.md
+++ b/CONTRIBUTING-template.md
@@ -173,7 +173,7 @@ These sections are not necessary, but can help streamline the contributions you 
 
 ### Explain if you use any commit message conventions.
 
-**Need inspiration?** [1] [Angular](https://github.com/angular/material/blob/master/CONTRIBUTING.md#-git-commit-guidelines) [2] [Node.js](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit)
+**Need inspiration?** [1] [Angular](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#submit) [2] [Node.js](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-3-commit)
 
 ### Explain if you use any labeling conventions for issues.
 


### PR DESCRIPTION
angular/material has some great contributing guidelines, but moved things around in their repo since this was written. This is a quick fix for the new location!